### PR TITLE
[git][submodule] fix cmake submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git@github.com:jrl-umi3218/jrl-cmakemodules.git
+	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Change cmake submodule path to public url
